### PR TITLE
Add error detection when sending content

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/HttpClientJsonExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor/HttpClientJsonExtensions.cs
@@ -101,6 +101,10 @@ namespace Microsoft.AspNetCore.Blazor
                 Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
             });
 
+            // Make sure the call was successful before we
+            // attempt to process the response content
+            response.EnsureSuccessStatusCode();
+
             if (typeof(T) == typeof(IgnoreResponse))
             {
                 return default;


### PR DESCRIPTION
As it stands, if the attempt to write (PUT/POST) content fails, for example, due to authorization (401) or some other server-side issue (50x), the error gets swallowed up.  Ensuring the call was successful will cause it to throw otherwise.

This also preserves symmetry with the `GetJsonAsync` counterpart since its underlying call to `GetStringAsync` already exhibits this behavior.
